### PR TITLE
Fix bug when seeding with no addresses.csv file

### DIFF
--- a/server/lib/address-generator.js
+++ b/server/lib/address-generator.js
@@ -11,7 +11,7 @@ export default class AddressGenerator {
       this.file = []
     }
 
-    this.indices = range(this.file.length - 1)
+    this.indices = this.file.length ? range(this.file.length - 1) : []
   }
 
   getOne() {


### PR DESCRIPTION
When this.file.length is 0 the range will still evaluate to [0] so I put a test to use [] when length is 0