### PR TITLE
Show server response and clear form on success

### DIFF
--- a/client/modules/users/components/ChangePassword.js
+++ b/client/modules/users/components/ChangePassword.js
@@ -22,6 +22,12 @@ class ChangePassword extends React.Component {
     this.props.clearFlags()
   }
 
+  componentWillReceiveProps = nextProps => {
+    if (nextProps.success) {
+      this.setState({currentPassword: "", newPassword: "", verifyPassword: ""})
+    }
+  }
+
   onFieldChange = e => {
     const { name, value } = e.target
     this.setState({ [name]: value })
@@ -38,8 +44,8 @@ class ChangePassword extends React.Component {
         <Col md={12}>
           <h3 className="col-md-12 text-center">Change your password</h3>
         </Col>
-        <Col xs={8} xsOffset={2} md={2} mdOffset={5}>
-          <LoadingWrapper loading={this.props.auth.fetching}>
+        <Col xs={8} xsOffset={2} md={4} mdOffset={4}>
+          <LoadingWrapper loading={this.props.fetching}>
             <form className="signin form-horizontal" autoComplete="off">
               <fieldset>
                 <FieldGroup
@@ -66,17 +72,31 @@ class ChangePassword extends React.Component {
                   value={this.state.verifyPassword}
                   placeholder="Verify Password"
                 />
+                {this.state.newPassword !== this.state.verifyPassword &&
+                  <div className="alert alert-danger">Passwords do not match</div>
+                }
                 <div className="text-center form-group">
-                  <button onClick={this.onSubmit} className="btn btn-large btn-primary">Save Password</button>
+                  <button
+                    onClick={this.onSubmit}
+                    className="btn btn-large btn-primary"
+                    disabled={
+                      !this.state.currentPassword ||
+                      !this.state.newPassword ||
+                      !this.state.verifyPassword ||
+                      this.state.newPassword !== this.state.verifyPassword
+                    }
+                  >
+                    Save Password
+                  </button>
                 </div>
-                {this.props.auth.success &&
+                {this.props.success &&
                   <div className="text-center text-success">
-                    <strong>{this.props.auth.success.message}</strong>
+                    <strong>{this.props.success.message}</strong>
                   </div>
                 }
-                {this.props.auth.error &&
+                {this.props.error &&
                   <div className="text-center text-danger">
-                    <strong>{this.props.auth.error}</strong>
+                    <strong>{this.props.error}</strong>
                   </div>
                 }
               </fieldset>
@@ -88,7 +108,9 @@ class ChangePassword extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  auth: selectors.user.getUser(state)
+  fetching: selectors.user.fetching(state),
+  error: selectors.user.error(state),
+  success: selectors.user.success(state)
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/client/modules/users/components/ForgotPassword.js
+++ b/client/modules/users/components/ForgotPassword.js
@@ -22,10 +22,8 @@ class ForgotPassword extends React.Component {
     this.props.clearFlags()
   }
 
-  redirectIfAlreadySignedIn(props) {
-    if (props.user && props.user._id) {
-      props.push('/')
-    }
+  componentWillReceiveProps = nextProps => {
+    this.redirectIfAlreadySignedIn(nextProps)
   }
 
   onFieldChange = e => {
@@ -38,17 +36,19 @@ class ForgotPassword extends React.Component {
     this.props.resetPassword(this.state.email)
   }
 
-  componentWillReceiveProps = nextProps => {
-    this.redirectIfAlreadySignedIn(nextProps)
+  redirectIfAlreadySignedIn(props) {
+    if (props.user && props.user._id) {
+      props.push('/')
+    }
   }
 
   render = () => {
     if (this.props.success) {
       return (
         <Row>
-          <Col xs={8} xsOffset={2} md={2} mdOffset={5}>
+          <Col xs={8} xsOffset={2} md={4} mdOffset={4}>
             <div className="text-center text-success">
-              <br/><strong>{this.props.success.message}</strong>
+              <br /><strong>{this.props.success.message}</strong>
             </div>
           </Col>
         </Row>
@@ -61,7 +61,7 @@ class ForgotPassword extends React.Component {
               <h3 className="text-center">Reset your password</h3>
             </Col>
             <p className="text-center">Enter your email address.</p>
-            <Col xs={8} xsOffset={2} md={2} mdOffset={5}>
+            <Col xs={8} xsOffset={2} md={4} mdOffset={4}>
               <LoadingWrapper loading={this.props.fetching}>
                 <form className="signin form-horizontal" autoComplete="off">
                   <fieldset>

--- a/client/modules/users/components/ResetPassword.js
+++ b/client/modules/users/components/ResetPassword.js
@@ -11,7 +11,7 @@ import LoadingWrapper from '../../../components/LoadingWrapper'
 
 class ResetPassword extends React.Component {
   constructor(props) {
-    super(props)  
+    super(props)
     this.state = {
       newPassword: "",
       verifyPassword: "",
@@ -25,6 +25,7 @@ class ResetPassword extends React.Component {
 
   componentWillReceiveProps = nextProps => {
     if (nextProps.success) {
+      this.setState({newPassword: "", verifyPassword: ""})
       setTimeout(() => this.props.redirect('/users/signin'), 3000)
     }
   }
@@ -38,9 +39,9 @@ class ResetPassword extends React.Component {
     e.preventDefault()
     this.props.clearFlags()
     if (this.state.newPassword !== this.state.verifyPassword) {
-      this.setState({ validationError: "Passwords do not match" }) 
+      this.setState({ validationError: "Passwords do not match" })
     } else if (this.state.newPassword.length === 0) {
-      this.setState({ validationError: "Password must not be blank" }) 
+      this.setState({ validationError: "Password must not be blank" })
     } else {
       this.props.changePassword(this.props.match.params.token, this.state.newPassword)
     }
@@ -48,55 +49,65 @@ class ResetPassword extends React.Component {
 
   render = () => {
     return (
-    <section>
-      <Row>
-        <Col md={12}>
-          <h3 className="col-md-12 text-center">Reset your password</h3>
-        </Col>
-        <Col xs={8} xsOffset={2} md={2} mdOffset={5}>
-          <LoadingWrapper loading={this.props.fetching}>
-            <form className="signin form-horizontal" autoComplete="off">
-              <fieldset>
-                <FieldGroup
-                  name="newPassword"
-                  type="password"
-                  label="New Password"
-                  onChange={this.onFieldChange}
-                  value={this.state.newPassword}
-                  placeholder="New Password"
-                />
-                <FieldGroup
-                  name="verifyPassword"
-                  type="password"
-                  label="Verify Password"
-                  onChange={this.onFieldChange}
-                  value={this.state.verifyPassword}
-                  placeholder="Verify Password"
-                />
-                <div className="text-center form-group">
-                  <button onClick={this.onSubmit} disabled={this.props.fetching} className="btn btn-large btn-primary">Save Password</button>
-                </div>
-                {this.state.validationError &&
+      <section>
+        <Row>
+          <Col md={12}>
+            <h3 className="col-md-12 text-center">Reset your password</h3>
+          </Col>
+          <Col xs={8} xsOffset={2} md={4} mdOffset={4}>
+            <LoadingWrapper loading={this.props.fetching}>
+              <form className="signin form-horizontal" autoComplete="off">
+                <fieldset>
+                  <FieldGroup
+                    name="newPassword"
+                    type="password"
+                    label="New Password"
+                    onChange={this.onFieldChange}
+                    value={this.state.newPassword}
+                    placeholder="New Password"
+                  />
+                  <FieldGroup
+                    name="verifyPassword"
+                    type="password"
+                    label="Verify Password"
+                    onChange={this.onFieldChange}
+                    value={this.state.verifyPassword}
+                    placeholder="Verify Password"
+                  />
+                  <div className="text-center form-group">
+                    <button
+                      onClick={this.onSubmit}
+                      className="btn btn-large btn-primary"
+                      disabled={
+                        this.props.fetching ||
+                        !this.state.newPassword ||
+                        !this.state.verifyPassword
+                      }
+                    >
+                    Save Password
+                  </button>
+                  </div>
+                  {this.state.validationError &&
                   <div className="text-center text-danger">
                     <strong>{this.state.validationError}</strong>
                   </div>
                 }
-                {this.props.success &&
+                  {this.props.success &&
                   <div className="text-center text-success">
                     <strong>{this.props.success.message}</strong>
                   </div>
                 }
-                {this.props.error &&
+                  {this.props.error &&
                   <div className="text-center text-danger">
                     <strong>{this.props.error}</strong>
                   </div>
                 }
-              </fieldset>
-            </form>
-          </LoadingWrapper>
-        </Col>
-      </Row>
-    </section>)
+                </fieldset>
+              </form>
+            </LoadingWrapper>
+          </Col>
+        </Row>
+      </section>)
   }
 }
 


### PR DESCRIPTION
As I worked on this, I realized that the change password page and reset password page were similar so I worked on both. There are some minor differences in handling that I left between the two because I'm not sure which you prefer. I also widened the medium columns because the error/success messages were getting squished and I thought it looked odd. Widened ForgotPassword to match and fixed lint errors.

Let me know if you think anything needs to be changed.

Closes #73