### PR TITLE
Change the delete food item api to return the deleted food item id

### DIFF
--- a/client/modules/food/reducers/item.js
+++ b/client/modules/food/reducers/item.js
@@ -35,7 +35,6 @@ export const deleteFoodItem = (categoryId, foodItemId) => ({
   [CALL_API]: {
     endpoint: `admin/foods/${categoryId}/items/${foodItemId}`,
     method: 'DELETE',
-    responseSchema: foodCategorySchema,
     types: [actions.DELETE_REQUEST, actions.DELETE_SUCCESS, actions.DELETE_FAILURE]
   }
 })
@@ -51,16 +50,19 @@ export default (state = {
         saving: true,
         saveError: null
       }
-    case actions.SAVE_SUCCESS:
-    case actions.DELETE_SUCCESS: {
-      // save (and delete?) returns the whole updated food category
+    case actions.SAVE_SUCCESS: {
+      // save returns the whole updated food category
       const result = action.response.entities.foodItems ? Object.keys(action.response.entities.foodItems) : []
-
       return {
         ...state,
-        ids: action.type === actions.DELETE_SUCCESS ?
-                              difference(state.ids, result) :
-                              union(state.ids, result),
+        ids: union(state.ids, result),
+        saving: false
+      }
+    }
+    case actions.DELETE_SUCCESS: {
+      return {
+        ...state,
+        ids: difference(state.ids, [action.response.deletedItemId]),
         saving: false
       }
     }

--- a/server/controllers/food.js
+++ b/server/controllers/food.js
@@ -119,17 +119,10 @@ export default {
    * Delete a food item
    */
   async deleteItem(req, res) {
-    const id = req.food._id
-
-    const savedFood = await Food.findByIdAndUpdate(
-      id,
-      { $pull: { items: { _id: req.itemId } } }, {new: true}
-    ).lean()
-
-    // const deletedItem = savedFood.items.filter(item =>
-    //   item._id.toString() === req.itemId)
-
-    res.json(savedFood)
+    const categoryId = req.food._id
+    const foodItemId = req.itemId
+    await Food.findByIdAndUpdate(categoryId, { $pull: { items: { _id: foodItemId } } })
+    res.json({deletedItemId: req.itemId})
   },
 
   /**

--- a/server/tests/integration/food.spec.js
+++ b/server/tests/integration/food.spec.js
@@ -235,12 +235,20 @@ describe('Food Api', function() {
 
       const itemId = savedCategoryWithItem.items[0]._id
 
-      return request.delete(`/api/admin/foods/${savedCategory._id}/items/${itemId}`)
-        .expect(res => {
-          expect(res.body).to.have.property('items')
-          expect(res.body.items).to.have.length(0)
-        })
+      await request.delete(`/api/admin/foods/${savedCategory._id}/items/${itemId}`)
         .expect(200)
+        .expect(res => {
+          expect(res.body).to.have.property('deletedItemId')
+          expect(res.body.deletedItemId).to.equal(itemId)
+        })
+
+      // Fetch the foods to make sure it is not still there
+      return request.get('/api/admin/foods')
+        .expect(200)
+        .expect(res => {
+          expect(res.body).to.have.length(1)
+          expect(res.body[0].items).to.have.length(0)
+        })
     })
   })
 })


### PR DESCRIPTION
and update reducer to fix bug when deleting items

I couldn't figure out how to get the reducer to update the food items properly when the api returned the category so I changed the api so that it just returns the deleted itemId.  Then the reducer can simply remove this id from the list of food items.

Closes #88